### PR TITLE
Fix typo

### DIFF
--- a/src/Scanner/ClassImplementerScanner.php
+++ b/src/Scanner/ClassImplementerScanner.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
 /**
  * @see \TomasVotruba\Lavarle\Tests\Scanner\ClassImplementerScanner\ClassImplementerScannerTest
  */
-final class ClassImlementerScanner
+final class ClassImplementerScanner
 {
     /**
      * @param string[] $directories

--- a/src/functions.php
+++ b/src/functions.php
@@ -6,7 +6,7 @@ namespace TomasVotruba\Lavarle;
 
 use Illuminate\Container\RewindableGenerator;
 use Illuminate\Contracts\Foundation\Application;
-use TomasVotruba\Lavarle\Scanner\ClassImlementerScanner;
+use TomasVotruba\Lavarle\Scanner\ClassImplementerScanner;
 
 /**
  * @param string[] $directories
@@ -25,7 +25,7 @@ function tag_directory_by_interface(
         return;
     }
 
-    $implementerClasses = ClassImlementerScanner::findImplementers($directories, $interface);
+    $implementerClasses = ClassImplementerScanner::findImplementers($directories, $interface);
 
     foreach ($implementerClasses as $implementerClass) {
         $application->singleton($implementerClass);

--- a/tests/Scanner/ClassImplementerScanner/ClassImplementerScannerTest.php
+++ b/tests/Scanner/ClassImplementerScanner/ClassImplementerScannerTest.php
@@ -6,14 +6,14 @@ namespace TomasVotruba\Lavarle\Tests\Scanner\ClassImplementerScanner;
 
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
-use TomasVotruba\Lavarle\Scanner\ClassImlementerScanner;
+use TomasVotruba\Lavarle\Scanner\ClassImplementerScanner;
 use TomasVotruba\Lavarle\Tests\Scanner\ClassImplementerScanner\Fixture\SomeInterface;
 
 final class ClassImplementerScannerTest extends TestCase
 {
     public function test(): void
     {
-        $classImplementers = ClassImlementerScanner::findImplementers(
+        $classImplementers = ClassImplementerScanner::findImplementers(
             [__DIR__ . '/Fixture'],
             SomeInterface::class
         );
@@ -24,7 +24,7 @@ final class ClassImplementerScannerTest extends TestCase
     #[DoesNotPerformAssertions]
     public function testIgnoreNonExistingDirectory(): void
     {
-        ClassImlementerScanner::findImplementers(
+        ClassImplementerScanner::findImplementers(
             [__DIR__ . '/missing'],
             SomeInterface::class
         );


### PR DESCRIPTION
this just fixes a typo in a class name and all of its references :)

```
rename src/Scanner/{ClassImlementerScanner.php => ClassImplementerScanner.php}
```